### PR TITLE
Dependency fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 log/*
 config/conf.yml
 .idea/
-Gemfile.lock
 coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rspec'
+gem 'cucumber'
 gem 'metric_fu'
 gem 'mechanize'
 gem 'octokit'
 gem 'term-ansicolor'
 
 group :development, :testing do
+  gem 'rake'
   gem 'ZenTest'
   gem 'debugger'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,177 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.9.4)
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
+    addressable (2.3.5)
+    arrayfields (4.9.0)
+    atomic (1.1.14)
+    awesome_print (1.2.0)
+    bluff (0.1.0)
+    builder (3.2.2)
+    cane (2.6.0)
+      parallel
+    chronic (0.10.2)
+    churn (0.0.34)
+      chronic (>= 0.2.3)
+      hirb
+      json_pure
+      main
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.1)
+    code_analyzer (0.4.3)
+      sexp_processor
+    code_metrics (0.1.1)
+    coderay (1.1.0)
+    colored (1.2)
+    columnize (0.3.6)
+    cucumber (1.3.8)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12.1)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.0.2)
+    debugger (1.6.2)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.2.3)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.2.3)
+    diff-lcs (1.2.4)
+    domain_name (0.5.13)
+      unf (>= 0.0.5, < 1.0.0)
+    erubis (2.7.0)
+    faraday (0.8.8)
+      multipart-post (~> 1.2.0)
+    fattr (2.2.1)
+    flay (2.4.0)
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.0)
+    flog (4.1.2)
+      ruby_parser (~> 3.1, > 3.1.0)
+      sexp_processor (~> 4.0)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    hirb (0.7.1)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    i18n (0.6.5)
+    json_pure (1.8.0)
+    main (5.2.0)
+      arrayfields (>= 4.7.4)
+      chronic (>= 0.6.2)
+      fattr (>= 2.2.0)
+      map (>= 5.1.0)
+    map (6.5.1)
+    mechanize (2.7.2)
+      domain_name (~> 0.5, >= 0.5.1)
+      http-cookie (~> 1.0.0)
+      mime-types (~> 1.17, >= 1.17.2)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.4)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (>= 0.0.9, < 0.2)
+    metric_fu (4.4.4)
+      bluff
+      cane (~> 2.5, >= 2.5.2)
+      churn (~> 0.0.28)
+      code_metrics (~> 0.1)
+      coderay
+      flay (~> 2.1, >= 2.0.1)
+      flog (~> 4.1, >= 4.1.1)
+      metric_fu-Saikuro (>= 1.1.1.0)
+      multi_json
+      rails_best_practices (~> 1.14, >= 1.14.3)
+      redcard
+      reek (~> 1.3, >= 1.3.3)
+      roodi (~> 3.1)
+    metric_fu-Saikuro (1.1.1.0)
+    mime-types (1.25)
+    mini_portile (0.5.1)
+    minitest (4.7.5)
+    multi_json (1.8.2)
+    multi_test (0.0.2)
+    multipart-post (1.2.0)
+    net-http-digest_auth (1.4)
+    net-http-persistent (2.9)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    ntlm-http (0.1.1)
+    octokit (2.4.0)
+      sawyer (~> 0.5.1)
+    parallel (0.8.4)
+    rails_best_practices (1.14.4)
+      activesupport
+      awesome_print
+      code_analyzer (>= 0.4.3)
+      colored
+      erubis
+      i18n
+      require_all
+      ruby-progressbar
+    rake (10.1.0)
+    redcard (1.1.0)
+    reek (1.3.4)
+      ruby2ruby (~> 2.0.2)
+      ruby_parser (~> 3.2)
+      sexp_processor
+    require_all (1.3.1)
+    roodi (3.1.1)
+      ruby_parser (~> 3.2, >= 3.2.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.3)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.3)
+    ruby-progressbar (1.2.0)
+    ruby2ruby (2.0.6)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.2.2)
+      sexp_processor (~> 4.1)
+    sawyer (0.5.1)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+    sexp_processor (4.3.0)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
+    term-ansicolor (1.2.2)
+      tins (~> 0.8)
+    thread_safe (0.1.3)
+      atomic
+    tins (0.12.0)
+    tzinfo (0.3.38)
+    unf (0.1.2)
+      unf_ext
+    unf_ext (0.0.6)
+    webrobots (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ZenTest
+  addressable
+  cucumber
+  debugger
+  mechanize
+  metric_fu
+  octokit
+  rake
+  rspec
+  simplecov
+  simplecov-rcov
+  term-ansicolor

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 # -*- mode: ruby -*-
 
 require 'cucumber/rake/task'
-
 Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = "--format pretty"
 end
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
Rag wasn't usable out of the box without manually installing Rake and Cucumber globally. This fixes that.