### PR TITLE
source http://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'rspec'
 gem 'metric_fu'


### PR DESCRIPTION
update Gemfile from deprecated source :rubygems, hope to have fewer failing builds due to timeout in bundle install
