### PR TITLE
[Works OK, but have the travis secure env var problem] Cache gems on s3 for quicker travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ bundler_args: --without development --path=~/.bundle
 before_install:
 - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
 - gem install bundler bundle_cache
-- bundle config build.nokogiri --use-system-libraries
+#- bundle config build.nokogiri --use-system-libraries
 - bundle_cache_install
 script:
 - bundle exec rspec spec


### PR DESCRIPTION
- bundle_cache gem depends on nokogiri unfortunately so still has to install that
- shaves about 2 minutes; see https://travis-ci.org/apelade/rag/builds
- **build will fail** because secure env vars on a fork, **but see it work at https://github.com/apelade/rag/pull/8**
