### PR TITLE
[Fix CI] Specify rspec 2.14.x in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
+gem 'rspec', '~> 2.14.1'
 gem 'metric_fu'
 gem 'mechanize'
 gem 'octokit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,184 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.10.0)
+    activesupport (4.1.1)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    addressable (2.3.6)
+    arrayfields (4.9.2)
+    awesome_print (1.2.0)
+    builder (3.2.2)
+    cane (2.6.2)
+      parallel
+    chronic (0.10.2)
+    churn (0.0.35)
+      chronic (>= 0.2.3)
+      hirb
+      json_pure
+      main
+      rest-client (>= 1.6.0)
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.1)
+    code_analyzer (0.4.5)
+      sexp_processor
+    code_metrics (0.1.3)
+    coderay (1.1.0)
+    colored (1.2)
+    columnize (0.8.9)
+    cucumber (1.3.15)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.1)
+    debugger (1.6.8)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.5)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    domain_name (0.5.19)
+      unf (>= 0.0.5, < 1.0.0)
+    erubis (2.7.0)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    fattr (2.2.2)
+    flay (2.5.0)
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.0)
+    flog (4.2.1)
+      ruby_parser (~> 3.1, > 3.1.0)
+      sexp_processor (~> 4.4)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    hirb (0.7.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    i18n (0.6.9)
+    json (1.8.1)
+    json_pure (1.8.1)
+    launchy (2.4.2)
+      addressable (~> 2.3)
+    main (6.0.0)
+      arrayfields (>= 4.7.4)
+      chronic (>= 0.6.2)
+      fattr (>= 2.2.0)
+      map (>= 5.1.0)
+    map (6.5.3)
+    mechanize (2.7.3)
+      domain_name (~> 0.5, >= 0.5.1)
+      http-cookie (~> 1.0)
+      mime-types (~> 2.0)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.4)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (>= 0.0.9, < 0.2)
+    metric_fu (4.11.1)
+      cane (~> 2.5, >= 2.5.2)
+      churn (~> 0.0.35)
+      code_metrics (~> 0.1)
+      coderay
+      flay (~> 2.1, >= 2.0.1)
+      flog (~> 4.1, >= 4.1.1)
+      launchy (~> 2.0)
+      metric_fu-Saikuro (~> 1.1, >= 1.1.3)
+      multi_json
+      rails_best_practices (~> 1.14, >= 1.14.3)
+      redcard
+      reek (~> 1.3, >= 1.3.4)
+      roodi (~> 3.1)
+    metric_fu-Saikuro (1.1.3)
+    mime-types (2.3)
+    mini_portile (0.6.0)
+    minitest (5.3.4)
+    multi_json (1.10.1)
+    multi_test (0.1.1)
+    multipart-post (2.0.0)
+    net-http-digest_auth (1.4)
+    net-http-persistent (2.9.4)
+    nokogiri (1.6.2.1)
+      mini_portile (= 0.6.0)
+    ntlm-http (0.1.1)
+    octokit (3.1.2)
+      sawyer (~> 0.5.3)
+    parallel (1.0.0)
+    rails_best_practices (1.15.4)
+      activesupport
+      awesome_print
+      code_analyzer (>= 0.4.3)
+      colored
+      erubis
+      i18n
+      json
+      require_all
+      ruby-progressbar
+    rainbow (2.0.0)
+    redcard (1.1.0)
+    reek (1.3.7)
+      rainbow
+      ruby2ruby (~> 2.0.8)
+      ruby_parser (~> 3.3)
+      sexp_processor
+    require_all (1.3.2)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    roodi (3.3.1)
+      ruby_parser (~> 3.2, >= 3.2.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    ruby-progressbar (1.5.1)
+    ruby2ruby (2.0.8)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.6.1)
+      sexp_processor (~> 4.1)
+    sawyer (0.5.4)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+    sexp_processor (4.4.3)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
+    thread_safe (0.3.4)
+    tins (1.3.0)
+    tzinfo (1.2.1)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.6)
+    webrobots (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ZenTest
+  addressable
+  cucumber
+  debugger
+  mechanize
+  metric_fu
+  octokit
+  rspec (~> 2.14.1)
+  simplecov
+  simplecov-rcov
+  term-ansicolor


### PR DESCRIPTION
- `~> 2.14.1` works with the rag spec/run_with_timeout_spec.rb
- `2.99.x` makes that spec fail.
- Possibly we should lock cucumber too. It's been 1.3.10 for a while now.
