### PR TITLE
remove stacktrace like lines from output of rspec_grader_run

### DIFF
--- a/lib/graders/feature_grader/hw4_grader.rb
+++ b/lib/graders/feature_grader/hw4_grader.rb
@@ -117,6 +117,11 @@ module Graders
 
 
     def load_description
+      if File.directory? @description
+        # gets the first yaml file
+        dir = Dir[File.join(@description, '*.yml')]
+        @description = dir[0]
+      end
       y = YAML::load_file(@description)
 
       # Load stuff we would need

--- a/lib/graders/rspec_grader/rspec_grader.rb
+++ b/lib/graders/rspec_grader/rspec_grader.rb
@@ -49,7 +49,10 @@ module Graders
         points_max += example[:points]
         points += example[:points] if example[:status] == 'passed'
       end
-       {raw_score: points, raw_max: points_max, comments: [output.string, errs.string].join("\n")}
+       sss = output.string.split(/\n/).select {|b| !b.match(/^    *# .*/) }
+       # puts("XXXXXX"+sss.join("\n")+"YYYYYYYYY")
+       # {raw_score: points, raw_max: points_max, comments: [output.string, errs.string].join("\n")}
+       {raw_score: points, raw_max: points_max, comments: [sss, errs.string].join("\n")}
     end
 
     def runner_block

--- a/lib/submission/xqueue.rb
+++ b/lib/submission/xqueue.rb
@@ -18,8 +18,8 @@ module Submission
     def next_submission_with_assignment
       submission = @x_queue.get_submission
       return if submission.nil?
-      logger.debug('XQueue adapter received submission.')
       submission.assignment = Assignment::Xqueue.new(submission)
+      logger.info("XQueue adapter received submission. Student #{submission.student_id} assignment #{submission.assignment.assignment_name}")
       submission.write_to_location! File.join( [ENV['BASE_FOLDER'], submission.student_id].join(''),
                         submission.assignment.assignment_name, Time.new.strftime(STRFMT))
       submission

--- a/spec/fixtures/ruby_intro_part1_broken.rb
+++ b/spec/fixtures/ruby_intro_part1_broken.rb
@@ -1,0 +1,8 @@
+# Returns the sum of all the numbers in `collection`, which must be 
+# enumerable
+def sum(collection)
+  collection[10] *= collection
+end
+
+
+sum([1, 2, 4])

--- a/spec/graders/rspec_grader_spec.rb
+++ b/spec/graders/rspec_grader_spec.rb
@@ -20,5 +20,20 @@ describe RspecGrader do
       expect(b[:raw_score]).to be == 30
     end
   end
+
+  context 'should be fail gracefully on bad homework' do
+    before(:each) do
+      FakeWeb.register_uri(:get, 'http://fixture.net/correct_submission.rb', body: IO.read('spec/fixtures/ruby_intro_part1_broken.rb'))
+      submission = ::XQueueSubmission.create_from_JSON(double, IO.read('spec/fixtures/x_queue_submission.json')).fetch_files!
+      submission.write_to_location! 'submissions/'
+      @submission_path = submission.files.values.first
+      @assignment = Assignment::Xqueue.new(submission)
+      @grader = AutoGrader.create(@submission_path, @assignment)
+    end
+    it 'gives points to a hw1 solution' do
+      b = @grader.grade
+      expect(b[:raw_score]).to be == 0
+    end
+  end
 end
 # FakeFS.deactivate!


### PR DESCRIPTION
Use a simple regex string filter to remove the stack traces from the results output returned to the reader