### PR TITLE
Improve performance of `auto_grader_spec` test

### DIFF
--- a/spec/graders/auto_grader_spec.rb
+++ b/spec/graders/auto_grader_spec.rb
@@ -22,7 +22,7 @@ describe AutoGrader do
   context 'restricts running time of test suites' do
     before(:each) do
       FakeWeb.register_uri(:get, 'http://fixture.net/timeout_submission.rb', body: IO.read('spec/fixtures/timeout_submission.rb'))
-      submission = ::XQueueSubmission.create_from_JSON(double, IO.read('spec/fixtures/x_queue_submission_timeout.json')).fetch_files!
+      submission = ::XQueueSubmission.create_from_JSON(double, IO.read('spec/fixtures/x_queue_submission_timeout.json'))
       submission.write_to_location! 'submissions/'
       @submission_path = submission.files.values.first
       @assignment = Assignment::Xqueue.new(submission)


### PR DESCRIPTION
Removing the call to `fetch_files!` improves the performance of the test by 2 seconds(approximately). What `fetch_files!` does is unnecessary, here is the method:
```ruby
  def fetch_files!
    if files
      file_agent = Mechanize.new
      @files = @files.inject({}) {|new_hash, (k,v)| new_hash[k] = file_agent.get_file(v); new_hash}
    end
    self
  end
```
If you replace that with:
```ruby
  def fetch_files!
    if files
      # use Net library instead of Mechanize, since in this case they do the exact same 
      # thing, I did this just to figure out what file_agent.get_file(v) was doing
      @files = @files.inject({}) {|new_hash, (k,v)| new_hash[k] = Net::HTTP.get(v); new_hash}
    end
    self
  end
```
It replaces the value of the key `"my_file.rb"` inside the `@files` hash of `submission` with the content of the URI specified in the test: `http://fixture.net/timeout_submission.rb` that poins to the file `spec/fixtures/timeout_submission.rb`. After that, it runs `submission.write_to_location! 'submissions/` which basically replaces with `'submissions/'` what it has just replaced, without using the previous value. I've run the test without the `fetch_files!` and it pass, also I did a few performance tests, here are the results:
```shell
# Run the test with `fetch_files!`
$ time rspec spec/graders/auto_grader_spec.rb:22
...... All green
-> 3.35s user 0.33s system 96% cpu 3.817 total

# Run the test without `fetch_files!`
$ time rspec spec/graders/auto_grader_spec.rb:22
.... All green
-> 1.54s user 0.32s system 96% cpu 1.931 total
```
I know it's only two seconds, but when you're running the entire test suite, I think those 2 seconds count. :+1: 