### PR TITLE
remove duplicate requires from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,6 @@ group :development, :testing do
   gem 'addressable'
   gem 'timecop'
   gem 'database_cleaner'
-  gem 'rspec'
-  gem 'rspec-collection_matchers'
-  gem 'rspec-its'
   gem 'nokogiri'
-  gem 'byebug'
   gem 'activemodel'
 end


### PR DESCRIPTION
```
$ bundle
Your Gemfile lists the gem rspec (>= 0) more than once.
Your Gemfile lists the gem rspec-collection_matchers (>= 0) more than once.
Your Gemfile lists the gem rspec-its (>= 0) more than once.
Your Gemfile lists the gem byebug (>= 0) more than once.
```
it looks like these were introduced in e1d94a5b7785ba0da475eb1102fcce5709148ca5 'adds gems for oob assignment' on Jan 20

